### PR TITLE
Catching errors when the track is not playing

### DIFF
--- a/main.py
+++ b/main.py
@@ -35,6 +35,11 @@ def set_standart_status():
 def set_status():
     global last_track
     current_track = spotify.current_user_playing_track()
+
+    if current_track is None:
+        set_standart_status()
+        return
+
     track = current_track["item"]["name"]
     album = current_track["item"]["album"]["name"]
     artist = current_track["item"]["artists"][0]["name"]


### PR DESCRIPTION
Если трек стоит на паузе, то `current_track`, в следствие чего возникает ошибка `TypeError: 'NoneType' object is not subscriptable` Добавил проверку ¯\\_(ツ)_/¯